### PR TITLE
Fix URL for build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ui-responsive-toolkit ![ ](https://travis-ci.org/lifegadget/ui-responsive-toolbelt.svg) [![npm version](https://badge.fury.io/js/ui-responsive-toolbelt.svg)](http://badge.fury.io/js/ui-responsive-toolbelt) [![Code Climate](https://codeclimate.com/github/lifegadget/ui-responsive-toolbelt/badges/gpa.svg)](https://codeclimate.com/github/lifegadget/ui-responsive-toolbelt) #
+# ui-responsive-toolkit ![build status](https://travis-ci.org/lifegadget/ui-responsive.svg) [![npm version](https://badge.fury.io/js/ui-responsive-toolbelt.svg)](http://badge.fury.io/js/ui-responsive-toolbelt) [![Code Climate](https://codeclimate.com/github/lifegadget/ui-responsive-toolbelt/badges/gpa.svg)](https://codeclimate.com/github/lifegadget/ui-responsive-toolbelt) #
 
 
 > Responsive tools for your Ember app


### PR DESCRIPTION
The URL for the build status badge in the README was using the repo name 'ui-responsive-toolbelt' which was causing the build status page to fail to appear.

FYI, the other badges are still using the old repo name; I didn't check/change any of those, however.
